### PR TITLE
align verification with api auto-decode

### DIFF
--- a/src/verifier/core/verifying.py
+++ b/src/verifier/core/verifying.py
@@ -253,10 +253,10 @@ class RequestVerifierResourceEnd:
             raise falcon.HTTPForbidden(description=f"identifier {aid} has no valid credential for access")
 
         kever = self.hby.kevers[aid]
-        verfers = kever.ververs
+        verfers = kever.verfers
         cigar = coring.Cigar(qb64=sig)
 
-        if not verfers[0].verify(sig=cigar.raw, ser=data.decode("utf-8")):
+        if not verfers[0].verify(sig=cigar.raw, ser=data.encode("utf-8")):
             raise falcon.HTTPUnauthorized(description=f"{aid} provided invalid signature on request data")
 
         rep.status = falcon.HTTP_ACCEPTED


### PR DESCRIPTION
UTF-8 encoding was needed to verify the signature (similar to KERIA https://github.com/WebOfTrust/keria/blob/afa1c9be486d40e21811692ea9aeb9d8bb84e014/src/keria/core/authing.py#L93) 